### PR TITLE
fix stuck processes when terminating

### DIFF
--- a/packages/gateway/start.js
+++ b/packages/gateway/start.js
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2020 Cedalo AG
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -20,6 +20,7 @@ const packageJSON = require('../package.json');
 const initContext = require('./src/context').init;
 const config = require('./src/config');
 const path = require('path');
+const process = require('process');
 
 const logger = LoggerFactory.createLogger('Gateway Service', process.env.GATEWAY_SERVICE_LOG_LEVEL);
 
@@ -44,6 +45,15 @@ const run = async () => {
 	await service.start();
 	initializer.setup(service);
 	logger.info('Gateway service started');
+
+	process.on('SIGTERM', () => {
+		logger.warn('SIGTERM signal received.');
+		service.stop().then(() => {
+			logger.warn('Service stopped. Exiting ...');
+			process.exit(0);
+		});
+	});
+
 };
 
 run();

--- a/packages/service-graphs/start.js
+++ b/packages/service-graphs/start.js
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2020 Cedalo AG
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -12,6 +12,7 @@ const GraphService = require('./src/services/graphs/GraphService');
 const metadata = require('./meta.json');
 const packageJSON = require('./package.json');
 const { LoggerFactory } = require('@cedalo/logger');
+const process = require('process');
 
 const logger = LoggerFactory.createLogger(
 	'Graph Service',
@@ -27,3 +28,11 @@ service
 	.then(() => {
 		logger.info('Graph service started');
 	});
+
+process.on('SIGTERM', () => {
+	logger.warn('SIGTERM signal received.');
+	service.stop().then(() => {
+		logger.warn('Service stopped. Exiting ...');
+		process.exit(0);
+	});
+});

--- a/packages/service-machines/start.js
+++ b/packages/service-machines/start.js
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2020 Cedalo AG
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -12,6 +12,7 @@ const MachineService = require('./src/machines/MachineService');
 const metadata = require('./meta.json');
 const packageJSON = require('./package.json');
 const logger = require('./src/utils/logger').create({ name: 'Machine Service' });
+const process = require('process');
 
 
 metadata.version = packageJSON.version;
@@ -28,3 +29,11 @@ service
 	.then(() => {
 		logger.info('Machine service started');
 	});
+
+process.on('SIGTERM', () => {
+	logger.warn('SIGTERM signal received.');
+	service.stop().then(() => {
+		logger.warn('Service stopped. Exiting ...');
+		process.exit(0);
+	});
+});

--- a/packages/service-streams/start.js
+++ b/packages/service-streams/start.js
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2020 Cedalo AG
  *
- * This program and the accompanying materials are made available under the 
+ * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
  *
@@ -12,6 +12,7 @@ const StreamsService = require('./src/StreamsService');
 const metadata = require('./meta.json');
 const packageJSON = require('./package.json');
 const { LoggerFactory } = require('@cedalo/logger');
+const process = require('process');
 
 const logger = LoggerFactory.createLogger(
 	'Stream Service',
@@ -30,10 +31,18 @@ process.on('uncaughtException', (err) => {
 	logger.error(err);
 });
 
+const service = new StreamsService(metadata);
 const start = async () => {
-	const service = new StreamsService(metadata);
 	await service.start();
 	logger.info('Streams service started');
 };
+
+process.on('SIGTERM', () => {
+	logger.warn('SIGTERM signal received.');
+	service.stop().then(() => {
+		logger.warn('Service stopped. Exiting ...');
+		process.exit(0);
+	});
+});
 
 start();


### PR DESCRIPTION
Terminating a process with Ctrl-C or SIGTERM in Kubernetes leaves the process stuck. This change fixes the issue, by calling the `stop()` method on the services and then exiting the process.

This fixes both the behavior of having a stuck container, when pressing Ctrl-C, as well as pods which remain in the termination state until Kubernetes uses more force to kill the pods.