### PR TITLE
Don't send ack-request if there weren't messages.

### DIFF
--- a/packages/stream/toit/src/ToitConsumer.js
+++ b/packages/stream/toit/src/ToitConsumer.js
@@ -57,7 +57,7 @@ module.exports = class ToitConsumer extends sdk.ConsumerMixin(ToitConnector) {
 					})
 				}
 			} finally {
-				if (toAcknowledge.length != 0) {
+				if (toAcknowledge.length !== 0) {
 					let ackRequest = new toitSubscribeModel.AcknowledgeRequest();
 					ackRequest.setSubscription(subscription);
 					ackRequest.setEnvelopeIdsList(toAcknowledge);

--- a/packages/stream/toit/src/ToitConsumer.js
+++ b/packages/stream/toit/src/ToitConsumer.js
@@ -57,14 +57,16 @@ module.exports = class ToitConsumer extends sdk.ConsumerMixin(ToitConnector) {
 					})
 				}
 			} finally {
-				let ackRequest = new toitSubscribeModel.AcknowledgeRequest();
-				ackRequest.setSubscription(subscription);
-				ackRequest.setEnvelopeIdsList(toAcknowledge);
-				this.client.acknowledge(ackRequest, (err) => {
-					if (err) {
-						this.handleWarning(err);
-					}
-				});
+				if (toAcknowledge.length != 0) {
+					let ackRequest = new toitSubscribeModel.AcknowledgeRequest();
+					ackRequest.setSubscription(subscription);
+					ackRequest.setEnvelopeIdsList(toAcknowledge);
+					this.client.acknowledge(ackRequest, (err) => {
+						if (err) {
+							this.handleWarning(err);
+						}
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
The stream might trigger an event with no messages. In that case we are
not supposed to send an ack message.